### PR TITLE
fix(show-hide-input): fix binding id attribute

### DIFF
--- a/projects/ngx-show-hide-password/src/lib/show-hide-input.directive.ts
+++ b/projects/ngx-show-hide-password/src/lib/show-hide-input.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Renderer2, OnInit, OnDestroy } from '@angular/core';
+import { Directive, ElementRef, Renderer2, OnInit, OnDestroy, HostBinding, AfterViewInit, Input } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { ShowHideService } from './show-hide.service';
 
@@ -7,21 +7,23 @@ import { ShowHideService } from './show-hide.service';
 })
 export class ShowHideInputDirective implements OnInit, OnDestroy {
   private subscription: Subscription;
-  private id: string;
+  @Input() id: string;
 
-  constructor(
-    private service: ShowHideService,
-    private el: ElementRef,
-    private renderer: Renderer2
-  ) {
-    this.id = this.el.nativeElement.getAttribute('id');
+  private registerElementId() {
     if (!this.id) {
       throw new Error(`No attribute [id] found.`);
     }
     this.service.setShow(this.id, this.el.nativeElement.type !== 'password');
   }
 
+  constructor(
+    private service: ShowHideService,
+    private el: ElementRef,
+    private renderer: Renderer2
+  ) {  }
+
   ngOnInit(): void {
+    this.registerElementId();
     this.service
       .getObservable(this.id)
       .subscribe(show =>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -46,4 +46,17 @@
     </div>
   </div>
 
+  <div class="form-group">
+    <label>Test with directive with bound id.</label>
+    <div class="input-group input-group-sm">
+      <input [id]="bindId" class="form-control" type="password" name="password" placeholder="Password"
+             autocomplete="new-password" value="asdasda" showHideInput>
+      <div class="input-group-append ngx-show-hide-password">
+        <button class="btn btn-outline-primary" type="button" [showHideTrigger]="bindId">
+          <span [showHideStatus]="{materialIcon: true, show: 'show', hide: 'hide', id: bindId}"></span>
+        </button>
+      </div>
+    </div>
+  </div>
+
 </form>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,4 +3,6 @@ import { Component } from '@angular/core';
   selector: 'app-root',
   templateUrl: './app.component.html'
 })
-export class AppComponent {}
+export class AppComponent {
+  bindId = 'bindId'
+}


### PR DESCRIPTION
This fixes a bug when ShowHideInputDirective tries to find element id when using binding. Accessing the element id through nativeElement works only if the id is statically assigned `id="test"`. This enables the directive to access the element id in case of using angular binding `[id]="someValue"`. The directive no longer access the id through the native element but instead from an `@input` prop.